### PR TITLE
Change maxThreads property value to Ratpack's default value.

### DIFF
--- a/spring-boot-ratpack/src/main/java/ratpack/spring/config/RatpackProperties.java
+++ b/spring-boot-ratpack/src/main/java/ratpack/spring/config/RatpackProperties.java
@@ -37,6 +37,8 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StringUtils;
 
+import ratpack.server.ServerConfig;
+
 /**
  * @author Dave Syer
  * 
@@ -56,7 +58,7 @@ public class RatpackProperties {
 	@NotNull
 	private String contextPath = "";
 
-	private int maxThreads = 10; // Number of threads in protocol handler
+	private int maxThreads = ServerConfig.DEFAULT_THREADS; // Number of threads in protocol handler
 
 	private String templatesPath = "templates";
 	private int cacheSize = 100;


### PR DESCRIPTION
I changed RatpackProperties's maxThreads to ServerConfig.DEFAULT_THREADS since I think it would make more sense than fixed value 10. ServerConfig.DEFAULT_THREADS is set depending on available system prcessors.